### PR TITLE
Fix: Use os.path.dirname for cross-platform path handling in plot_glycans_excel

### DIFF
--- a/candycrunch/prediction.py
+++ b/candycrunch/prediction.py
@@ -1611,7 +1611,7 @@ def wrap_inference(spectra_filepath, glycan_class, model = candycrunch, glycans 
     df_out.index.name = "m/z"
     if plot_glycans:
         from glycowork.motif.draw import plot_glycans_excel
-        plot_glycans_excel(df_out, '/'.join(spectra_filepath.split("\\")[:-1])+'/', glycan_col_num = 0)
+        plot_glycans_excel(df_out, os.path.dirname(spectra_filepath), glycan_col_num = 0)
     return (df_out, spectra_out) if spectra else df_out
 
 


### PR DESCRIPTION
Related Issues #9

Problem:

When running `candycrunch_predict` on Linux/macOS, the code attempts to extract the directory from `spectra_filepath` using `split("\\")`, which is Windows-specific. This causes the path to be incorrectly resolved as the root directory `/`, leading to a `PermissionError` when trying to write `output.xlsx` to `/`.

Example error:

```
PermissionError: [Errno 13] Permission denied: '/output.xlsx'
```

Solution:
Replace the hardcoded Windows path splitting logic with `os.path.dirname()`, which correctly handles path separators across all operating systems (Linux, macOS, Windows).

Changes:

+ Replaced fragile` '/'.join(spectra_filepath.split("\\")[:-1])+'/'`
with robust `os.path.dirname(spectra_filepath)`
+ Removed trailing slash assumption — `plot_glycans_excel`  already handles path joining correctly

Testing:

Verified on Linux with the following command:

```
candycrunch_predict --spectra_filepath tests/data/GPST000017/JC_141128PGMa.xlsx --glycan_class N --output ./output.xlsx --plot_glycans True
```

✅ Output file and plots are now correctly saved in the input file's directory❤️.